### PR TITLE
Provide jclouds-jboss-modules also as tar.gz

### DIFF
--- a/src/main/assembly/modules.xml
+++ b/src/main/assembly/modules.xml
@@ -4,6 +4,7 @@
   <id>modules</id>
   <formats>
     <format>zip</format>
+    <format>tar.gz</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
   <fileSets>


### PR DESCRIPTION
Provide jclouds-jboss-modules also as tar.gz (more convenient then zip to include in Docker images)
